### PR TITLE
Fix httplug dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.0] - 2020-01-21
+### Removed
+
+* Support for ^1.0 releases of phphttp/httplug
+  * Code been changed to enforce the use of the `Psr\Http\Client\ClientInterface`. If you're using PHP-HTTP you will
+    find support for this in ^2.0.
+
 ## [2.1.1] - 2019-11-04
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php-http/message": "^1.1",
     "php-http/curl-client": "*",
     "php-http/mock-client": "*",
-    "php-http/socket-client": "*",
+    "php-http/socket-client": "2.0.0-beta1",
     "php-http/guzzle6-adapter": "*"
   },
   "suggest": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '2.1.0';
+    const VERSION = '2.2.0';
 
     /**
      * @const string The API endpoint for Notify production.

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,10 +1,10 @@
 <?php
 namespace Alphagov\Notifications;
 
-use GuzzleHttp\Psr7\Uri;                            // Concrete PSR-7 URL representation.
-use GuzzleHttp\Psr7\Request;                        // Concrete PSR-7 HTTP Request
-use Psr\Http\Message\ResponseInterface;             // PSR-7 HTTP Response Interface
-use Http\Client\HttpClient as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
+use GuzzleHttp\Psr7\Uri;                                    // Concrete PSR-7 URL representation.
+use GuzzleHttp\Psr7\Request;                                // Concrete PSR-7 HTTP Request
+use Psr\Http\Message\ResponseInterface;                     // PSR-7 HTTP Response Interface
+use Psr\Http\Client\ClientInterface as HttpClientInterface; // Interface for a PSR-7 compatible HTTP Client.
 
 use Alphagov\Notifications\Authentication\JWTAuthenticationInterface;
 


### PR DESCRIPTION
Make a tiny change to the notify library to get it using the PSR standards interfaces which means we can use it with our code.
